### PR TITLE
fix(build): fix javadoc generation

### DIFF
--- a/ci/scripts/generate_documentation.sh
+++ b/ci/scripts/generate_documentation.sh
@@ -64,7 +64,7 @@ DOC_PATH="development/code-documentation/$CIRCLE_BRANCH"
 # Generate javadoc this folder must be on .gitignore
 #javadoc -d $DOC_PATH -sourcepath ./inventory/src/main/java -subpackages . -bootclasspath $ANDROID_HOME/platforms/android-29/android.jar
 
-./gradlew :inventory:javadoc -PcustomDestination=$DOC_PATH
+./gradlew :app:javadoc -PcustomDestination=$DOC_PATH
 
 # delete the index.html file
 sudo rm $DOC_PATH/index.html


### PR DESCRIPTION
### Changes description

Fix gradle javadoc

```shell
Picked up _JAVA_OPTIONS: -Xmx2048m -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport

FAILURE: Build failed with an exception.

* What went wrong:
Project 'inventory' not found in root project 'flyve_mdm'.
```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@|1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A