### PR TITLE
Explicitly specify the charset when inventory posts.

### DIFF
--- a/app/src/main/java/org/glpi/inventory/agent/utils/DataLoader.java
+++ b/app/src/main/java/org/glpi/inventory/agent/utils/DataLoader.java
@@ -106,8 +106,8 @@ public class DataLoader {
 
         HttpPost post;
         post = new HttpPost(mFusionApp.getAddress());
-        post.setHeader("Content-Type","application/xml");
-        post.setHeader("Charset","UTF-8");
+        post.setHeader("Content-Type","application/xml;charset=utf-8");
+        // post.setHeader("Charset","UTF-8");
         sslClient.addRequestInterceptor(new HttpRequestInterceptor() {
             @Override
             public void process(HttpRequest request, HttpContext context) {


### PR DESCRIPTION
### Changes description

Most systems use UTF-8 as the internal encoding, but HTTP 1.1 specifies that the encoding used during transmission should be ISO 8859-1.
It is possible to specify which encoding the submitted body uses by adding ``charset=utf-8`` to Content-type header. However, this is currently undefined.
As a result, the encoding is lost, and in a non-English environment, we cannot tell what is being written.

The purpose of this pull request is to preserve the encoding by setting the Content-type header to ``application/xml;charset=utf-8`` .

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@|1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A