### PR TITLE
fix(build): fix Google Cloud SDK isntall

### DIFF
--- a/ci/scripts/setup_environment.sh
+++ b/ci/scripts/setup_environment.sh
@@ -41,6 +41,8 @@ echo GIT_BRANCH=$CIRCLE_BRANCH >> .env
 # decrypt deploy on google play file
 openssl aes-256-cbc -d -out ci/gplay.json -in ci/gplay.json.enc -k $ENCRYPTED_KEY
 
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
 # Maintenance commands
 sudo apt-get update
 

--- a/ci/scripts/setup_environment.sh
+++ b/ci/scripts/setup_environment.sh
@@ -49,6 +49,7 @@ sudo apt-get update
 # install gems
 sudo apt-get install ruby-full build-essential
 
+sudo apt-get install ruby-full
 # update Rubygems
 sudo gem update --system --no-document
 

--- a/ci/scripts/setup_environment.sh
+++ b/ci/scripts/setup_environment.sh
@@ -41,7 +41,7 @@ echo GIT_BRANCH=$CIRCLE_BRANCH >> .env
 # decrypt deploy on google play file
 openssl aes-256-cbc -d -out ci/gplay.json -in ci/gplay.json.enc -k $ENCRYPTED_KEY
 
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add
 
 # Maintenance commands
 sudo apt-get update

--- a/ci/scripts/setup_environment.sh
+++ b/ci/scripts/setup_environment.sh
@@ -55,9 +55,9 @@ curl -sSL https://rvm.io/mpapis.asc | sudo gpg2 --import -
 curl -sSL https://rvm.io/pkuczynski.asc | sudo gpg2 --import -
 curl -sSL https://get.rvm.io | sudo bash -s stable
 source /etc/profile.d/rvm.sh
-rvm requirements
-rvm install 2.6
-rvm use 2.6 --default
+sudo rvm requirements
+sudo rvm install 2.6
+sudo rvm use 2.6 --default
 
 # update Rubygems
 sudo gem update --system --no-document

--- a/ci/scripts/setup_environment.sh
+++ b/ci/scripts/setup_environment.sh
@@ -49,7 +49,16 @@ sudo apt-get update
 # install gems
 sudo apt-get install ruby-full build-essential
 
-sudo apt-get install ruby-full
+# update to 2.6.0
+sudo apt install curl gnupg2
+curl -sSL https://rvm.io/mpapis.asc | sudo gpg2 --import -
+curl -sSL https://rvm.io/pkuczynski.asc | sudo gpg2 --import -
+curl -sSL https://get.rvm.io | sudo bash -s stable
+source /etc/profile.d/rvm.sh
+rvm requirements
+rvm install 2.6
+rvm use 2.6 --default
+
 # update Rubygems
 sudo gem update --system --no-document
 


### PR DESCRIPTION
### Changes description

Fix ```build``` error

``` 
Reading package lists... Done
W: GPG error: https://packages.cloud.google.com/apt cloud-sdk-buster InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
E: The repository 'https://packages.cloud.google.com/apt cloud-sdk-buster InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.

Exited with code exit status 100

```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@|1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A