### PR TITLE
Fix(i18n): Exclude sensitive strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,7 @@
         <item>Week</item>
         <item>Month</item>
     </string-array>
-    <string-array name="AssetItemtype">
+    <string-array name="AssetItemtype" translatable="false">
         <item>Computer</item>
         <item>Phone</item>
     </string-array>


### PR DESCRIPTION
### Changes description

Exclude sensitive strings (which should not be translated)
Example from `pt-br`

![image](https://github.com/user-attachments/assets/9abfe4c1-95eb-42f4-ba4a-7f4ac076cf33)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

Fix : https://github.com/glpi-project/glpi-agent/discussions/805
